### PR TITLE
Allow IDE to find modules in node_modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
+    "moduleResolution": "node",
     "declaration": false,
     "noImplicitAny": false,
     "removeComments": true,


### PR DESCRIPTION
Not sure if this is the case for other IDEs but web storm is not able to resolve imports unless I add `"moduleResolution": "node"` to the typescript compiler options